### PR TITLE
ganeti/os/noop/export: Fix size detection for non-block devices.

### DIFF
--- a/ganeti/os/noop/export
+++ b/ganeti/os/noop/export
@@ -28,7 +28,11 @@
 # https://bugs.launchpad.net/ubuntu/+source/dash/+bug/249620
 
 if test -n "$EXP_SIZE_FD"; then
-  blockdev --getsize64 "$EXPORT_DEVICE" >&"$EXP_SIZE_FD"
+  if [ -f "$EXPORT_DEVICE" ]; then
+    stat -c '%s' "$EXPORT_DEVICE" >&"$EXP_SIZE_FD"
+  else
+    blockdev --getsize64 "$EXPORT_DEVICE" >&"$EXP_SIZE_FD"
+  fi
 fi
 
 dd if="$EXPORT_DEVICE" bs=1048576


### PR DESCRIPTION
Reported to Debian BTS as DebianBug:895602:
https://bugs.debian.org/895602

Thanks!
Mike